### PR TITLE
Fix image centering

### DIFF
--- a/src/identiconDirective.js
+++ b/src/identiconDirective.js
@@ -15,20 +15,40 @@ angular.module('ui.identicon', [])
             scope: {
                 username: '=',
                 size: '=',
-                naturalSize: '='
+                marginPx: '='
             },
             template: '<img width={{size}} height={{size}} ng-src="data:image/png;base64,{{data}}">',
             controller: function ($scope, md5) {
-                $scope.size = (typeof($scope.size) !== 'undefined' ? $scope.size : 24);
-                $scope.naturalSize = $scope.naturalSize;
-                if ((typeof($scope.naturalSize) === 'undefined')) {
-                    var n;
-                    for (n = 22; n < $scope.size; n+=12);
-                    $scope.naturalSize = ($scope.size < n - 5) ? n - 5 : n;
-                }
+				
+				function calculateMargin(size, marginPx) {
+					var NUM_COLUMNS = 5; // Identicons are a 5x5 grid
+					var MIN_CELL_SIZE = 20; // We don't want the margin to "overpower" the cell size
 
-                $scope.$watchGroup(['username', 'size'], function (newVal) {
-                    $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.naturalSize).toString();
+					// Users can pass in their own desired margin in pixels
+					if (typeof marginPx !== 'undefined') {
+						// convert their margin pixels into Identicon's expected percentage of size
+						return marginPx / size;
+					}
+					
+					// Calculate an acceptable margin
+					marginPx = (size % NUM_COLUMNS) / 2; // Any extra space can be margin space
+					
+					var cellSize = (size / NUM_COLUMNS);
+					
+					// For larger identicons with no extra space, make the margin 5.
+					if (marginPx === 0 && cellSize > MIN_CELL_SIZE) {
+						marginPx = 5;
+					}
+					
+					// convert the calculated margin pixels into Identicon's expected percentage of size
+					return marginPx / size;
+				}
+				
+                $scope.size = (typeof($scope.size) !== 'undefined' ? $scope.size : 24);
+                $scope.margin = calculateMargin($scope.size, $scope.marginPx);
+
+                $scope.$watchGroup(['username', 'size', 'marginPx'], function (newVal) {
+                    $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.size, $scope.margin).toString();
                 });
             }
         };

--- a/src/identiconDirective.js
+++ b/src/identiconDirective.js
@@ -20,7 +20,12 @@ angular.module('ui.identicon', [])
             template: '<img width={{size}} height={{size}} ng-src="data:image/png;base64,{{data}}">',
             controller: function ($scope, md5) {
                 $scope.size = (typeof($scope.size) !== 'undefined' ? $scope.size : 24);
-                $scope.naturalSize = (typeof($scope.naturalSize) !== 'undefined' ? $scope.naturalSize : 300);
+                $scope.naturalSize = $scope.naturalSize;
+                if ((typeof($scope.naturalSize) === 'undefined')) {
+                    var n;
+                    for (n = 22; n < $scope.size; n+=12);
+                    $scope.naturalSize = ($scope.size < n - 5) ? n - 5 : n;
+                }
 
                 $scope.$watchGroup(['username', 'size'], function (newVal) {
                     $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.naturalSize).toString();

--- a/src/identiconDirective.js
+++ b/src/identiconDirective.js
@@ -14,14 +14,16 @@ angular.module('ui.identicon', [])
             replace: true,
             scope: {
                 username: '=',
-                size: '='
+                size: '=',
+                naturalSize: '='
             },
             template: '<img width={{size}} height={{size}} ng-src="data:image/png;base64,{{data}}">',
             controller: function ($scope, md5) {
                 $scope.size = (typeof($scope.size) !== 'undefined' ? $scope.size : 24);
+                $scope.naturalSize = (typeof($scope.naturalSize) !== 'undefined' ? $scope.naturalSize : 300);
 
                 $scope.$watchGroup(['username', 'size'], function (newVal) {
-                    $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.size).toString();
+                    $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.naturalSize).toString();
                 });
             }
         };

--- a/src/identiconDirective.js
+++ b/src/identiconDirective.js
@@ -8,7 +8,7 @@
  * @restrict A
  * */
 angular.module('ui.identicon', [])
-    .directive('identicon', function () {
+    .directive('identicon', function() {
         return {
             restrict: 'E',
             replace: true,
@@ -18,37 +18,42 @@ angular.module('ui.identicon', [])
                 marginPx: '='
             },
             template: '<img width={{size}} height={{size}} ng-src="data:image/png;base64,{{data}}">',
-            controller: function ($scope, md5) {
-				
-				function calculateMargin(size, marginPx) {
-					var NUM_COLUMNS = 5; // Identicons are a 5x5 grid
-					var MIN_CELL_SIZE = 20; // We don't want the margin to "overpower" the cell size
+            controller: function($scope, md5) {
 
-					// Users can pass in their own desired margin in pixels
-					if (typeof marginPx !== 'undefined') {
-						// convert their margin pixels into Identicon's expected percentage of size
-						return marginPx / size;
-					}
-					
-					// Calculate an acceptable margin
-					marginPx = (size % NUM_COLUMNS) / 2; // Any extra space can be margin space
-					
-					var cellSize = (size / NUM_COLUMNS);
-					
-					// For larger identicons with no extra space, make the margin 5.
-					if (marginPx === 0 && cellSize > MIN_CELL_SIZE) {
-						marginPx = 5;
-					}
-					
-					// convert the calculated margin pixels into Identicon's expected percentage of size
-					return marginPx / size;
-				}
-				
-                $scope.size = (typeof($scope.size) !== 'undefined' ? $scope.size : 24);
-                $scope.margin = calculateMargin($scope.size, $scope.marginPx);
+                function centerImage(size, marginPx) {
+                    // Identicons are a 5x5 grid (without margins)
+                    var NUM_COLUMNS = 5;
+                    // With margins, however it's a 6x6 grid where the 6th row and column are split in half
+                    // and evenly spaced around the image, thus creating the margin.
 
-                $scope.$watchGroup(['username', 'size', 'marginPx'], function (newVal) {
-                    $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.size, $scope.margin).toString();
+                    // Users can pass in their own desired margin in pixels
+                    if (typeof marginPx !== 'undefined') {
+                        // convert their margin pixels into Identicon's expected percentage of size
+                        return {margin: marginPx / size, naturalSize: size};
+                    }
+
+                    // Calculate an acceptable natural size and margin
+                    var adjustment = (NUM_COLUMNS + 1) - (size % (NUM_COLUMNS + 1)); // adjustment needed to get a square fit for an identicon (divisble by 6)
+                    var naturalSize = size + adjustment; // at most, we'd generate an icon that's 5px bigger than the size the user requested and scale it down.
+                    marginPx = (naturalSize / (NUM_COLUMNS + 1)) / 2; // take a 6th of the newly calculated natural size and cut it in half for an even margin.
+
+                    // convert the calculated margin pixels into Identicon's expected percentage of size
+                    return {margin: marginPx / naturalSize, naturalSize: naturalSize};
+                }
+
+                function init() {
+                    $scope.size = (typeof($scope.size) !== 'undefined' ? $scope.size : 24);
+
+                    var adjustmentValues = centerImage($scope.size, $scope.marginPx);
+                    $scope.margin = adjustmentValues.margin;
+                    $scope.naturalSize = adjustmentValues.naturalSize;
+                }
+
+                init();
+
+                $scope.$watchGroup(['username', 'size', 'marginPx'], function(newVal) {
+                    init();
+                    $scope.data = new Identicon(md5.createHash($scope.username || ''), $scope.naturalSize, $scope.margin).toString();
                 });
             }
         };

--- a/src/identiconDirectiveSpec.js
+++ b/src/identiconDirectiveSpec.js
@@ -14,11 +14,11 @@ describe('Directive: ui.identicon', function () {
 
     /**
      * @description
-     * Ensures margin calculation is correct based on provided size and
+     * Ensures natural size calculation is correct based on provided size and
      * no provided marginPx.
      * */
-    it('should calculate a valid margin', function() {
-        expect($scope.margin).toBe(1);
+    it('should generate a larger image and scale to ensure even margins', function() {
+        expect($scope.naturalSize).toBe(36);
     });
 
     /**

--- a/src/identiconDirectiveSpec.js
+++ b/src/identiconDirectiveSpec.js
@@ -14,11 +14,11 @@ describe('Directive: ui.identicon', function () {
 
     /**
      * @description
-     * Ensures naturalSize calculation is correct based on provided size and
-     * no provided naturalSize.
+     * Ensures margin calculation is correct based on provided size and
+     * no provided marginPx.
      * */
-    it('should calculate a valid natural size', function() {
-        expect($scope.naturalSize).toBe(34);
+    it('should calculate a valid margin', function() {
+        expect($scope.margin).toBe(1);
     });
 
     /**

--- a/src/identiconDirectiveSpec.js
+++ b/src/identiconDirectiveSpec.js
@@ -6,11 +6,20 @@ describe('Directive: ui.identicon', function () {
     beforeEach(inject(function ($compile, $rootScope) {
         scope = $rootScope.$new();
 
-        ele = angular.element('<identicon hash="test@gmail.com" size="32"></identicon>');
+        ele = angular.element('<identicon username="test@gmail.com" size="32"></identicon>');
 
         $compile(ele)(scope);
         scope.$apply();
     }));
+
+    /**
+     * @description
+     * Ensures naturalSize calculation is correct based on provided size and
+     * no provided naturalSize.
+     * */
+    it('should calculate a valid natural size', function() {
+        expect($scope.naturalSize).toBe(34);
+    });
 
     /**
      * @description


### PR DESCRIPTION
Rendering at any given size would result in the identicon being
off-center. Rendering it at 300 and downsizing it seems to provide more
centered icons. Still allows users to specify natural size.
